### PR TITLE
Fix docker name checking

### DIFF
--- a/mplugins/check_docker/check_docker.py
+++ b/mplugins/check_docker/check_docker.py
@@ -30,8 +30,8 @@ class CheckDocker(MPlugin):
         id = None
         statj = None
 
-        for container in respj:
-            if container['name'] == container_name and container['Status'].startswith('Up'):
+        for name in container['Names']:
+            if container_name == name.split('/')[-1] and container['Status'].startswith('Up'):
                 id = container['Id']
 
         if id:

--- a/mplugins/check_docker/check_docker.py
+++ b/mplugins/check_docker/check_docker.py
@@ -30,9 +30,10 @@ class CheckDocker(MPlugin):
         id = None
         statj = None
 
-        for name in container['Names']:
-            if container_name == name.split('/')[-1] and container['Status'].startswith('Up'):
-                id = container['Id']
+        for container in respj:
+            for name in container['Names']:
+                if container_name == name.split('/')[-1] and container['Status'].startswith('Up'):
+                    id = container['Id']
 
         if id:
             stat_url = "/containers/%s/stats?stream=0" % id


### PR DESCRIPTION
Docker uses a herichable list named Names.
Docker-compose uses Docker's Label array where name is stored. But useless as name is not real container name but container image used.